### PR TITLE
Accept params as dictionary (default) or list (optional)

### DIFF
--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -47,6 +47,7 @@ jobs:
         run: |
           export PATH="$HOME/miniconda/bin:$PATH"
           source activate ${ENV_NAME}
+          pip install numpy
           pip install .[dev]
       - name: Run Tests
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     hera_pspec @ git+git://github.com/hera-team/hera_pspec
     hera_sim @ git+git://github.com/hera-team/hera_sim
     attr
+    cached_property
 
 [options.packages.find]
 where = src

--- a/src/pspec_likelihood/likelihood.py
+++ b/src/pspec_likelihood/likelihood.py
@@ -136,6 +136,7 @@ class PSpecLikelihood:
         self.kbin_widths = kbin_widths
         # add parameters that directly reference mean and covariance of measurements.
         # also add keywords that describe the data distribution.
+        assert isinstance(param_names, [None, list, tuple])
         self.param_names = param_names
 
     def discretized_ps(self, spw, theory_params, little_h=True, method=None):
@@ -249,22 +250,21 @@ class PSpecLikelihood:
         params : dictionary
             params convert to dictionary
         """
-        if self.param_names is not None:
-            assert type(params) is list, (
-                "params is not a list, but param_names was given. "
-                "When params is a dictionary, leave param_names set to None."
-            )
-            params_dict = {}
-            for index in len(self.param_names):
-                key = self.param_names[index]
-                params_dict[key] = params[index]
-            params = params_dict
+        if isinstance(params, dict):
+            if self.param_names is not None:
+                assert set(self.param_names) == set(
+                    params.keys()
+                ), "input parameters don't match parameters of the likelihood"
+            return params
         else:
-            assert type(params) is dict, (
-                "params is not a dictionary, but no param_names was given. "
-                "params can be a dictionary, or a list if param_names is supplied."
-            )
-        return params
+            if self.param_names is None:
+                raise ValueError(
+                    "To pass params as a sequence, rather than dict, likelihood must be created with param_names"
+                )
+            assert isinstance(
+                params, [list, tuple]
+            ), "input parameters must be either dict, list or tuple"
+            return {k: v for k, v in zip(self.param_names, params)}
 
     def log_unnormalized_likelihood(self, params):
         r"""

--- a/src/pspec_likelihood/likelihood.py
+++ b/src/pspec_likelihood/likelihood.py
@@ -231,9 +231,8 @@ class PSpecLikelihood:
         windows_ps = self.measurements.get_window_function(spw)
         return discretized_ps, windows_ps
 
-    @staticmethod
-    def get_z_from_spw(spw) -> float:
-        """Get redshift from a spectral window."""
+    def get_z_from_spw(self, spw):
+        r"""Get redshift from a spectral window."""
         # TODO: get redshift(s) z from spw / integrate
         raise NotImplementedError("Need to implement this.")
 
@@ -250,22 +249,21 @@ class PSpecLikelihood:
         params : dictionary
             params convert to dictionary
         """
-
         if self.params_list is not None:
-            assert (
-                type(params) is list
-            ), ("params is not a list, but params_list was given. "
-                "When params is a dictionary, leave params_list set to None.")
+            assert type(params) is list, (
+                "params is not a list, but params_list was given. "
+                "When params is a dictionary, leave params_list set to None."
+            )
             params_dict = {}
             for index in len(self.params_list):
                 key = self.params_list[index]
                 params_dict[key] = params[index]
             params = params_dict
         else:
-            assert (
-                type(params) is dict
-            ), ("params is not a dictionary, but no params_list was given. "
-                "params can be a dictionary, or a list if params_list is supplied.")
+            assert type(params) is dict, (
+                "params is not a dictionary, but no params_list was given. "
+                "params can be a dictionary, or a list if params_list is supplied."
+            )
         return params
 
     def log_unnormalized_likelihood(self, params):
@@ -281,6 +279,6 @@ class PSpecLikelihood:
             This is the only function that accepts params as list or dict, other
             functions get called from here and take a dictionary.
         """
-        params = params_to_dict(params)
+        params = self.params_to_dict(params)
         raise NotImplementedError
         pass

--- a/src/pspec_likelihood/likelihood.py
+++ b/src/pspec_likelihood/likelihood.py
@@ -23,10 +23,9 @@ This class keeps track of power-spectrum measurements
 
  How do we keep track of sampling?
 """
-from functools import cached_property
-
 import attr
 import numpy as np
+from cached_property import cached_property
 from hera_pspec import grouping
 from hera_pspec.uvpspec import UVPSpec
 from scipy.integrate import quad

--- a/src/pspec_likelihood/likelihood.py
+++ b/src/pspec_likelihood/likelihood.py
@@ -45,7 +45,7 @@ class PSpecLikelihood:
         weight_by_cov=True,
         history="",
         run_check=True,
-        params_list=None,
+        param_names=None,
     ):
         r"""Container for power spectrum measurements and models.
 
@@ -80,10 +80,10 @@ class PSpecLikelihood:
             a list of floats specifying the centers of k-bins.
         history : str
             string with file history.
-        params_list: list of strings
+        param_names: list of strings
             list of parameter names if params is list, otherwise None.
             log_unnormalized_likelihood can take params as either a dictionary
-            or a list of values. In the latter case, params_list needs to
+            or a list of values. In the latter case, param_names needs to
             be given as the list of corresponding parameter names (keys) so
             the list can internally be converted to a dictionary.
 
@@ -136,7 +136,7 @@ class PSpecLikelihood:
         self.kbin_widths = kbin_widths
         # add parameters that directly reference mean and covariance of measurements.
         # also add keywords that describe the data distribution.
-        self.params_list = params_list
+        self.param_names = param_names
 
     def discretized_ps(self, spw, theory_params, little_h=True, method=None):
         r"""Compute the power spectrum in the specified spectral windows and k_bins.
@@ -238,7 +238,7 @@ class PSpecLikelihood:
 
     def params_to_dict(self, params):
         r"""
-        Check if params is a list or dictionary. If list convert to dictionary using params_list.
+        Check if params is a list or dictionary. If list convert to dictionary using param_names.
 
         Parameters
         ----------
@@ -249,20 +249,20 @@ class PSpecLikelihood:
         params : dictionary
             params convert to dictionary
         """
-        if self.params_list is not None:
+        if self.param_names is not None:
             assert type(params) is list, (
-                "params is not a list, but params_list was given. "
-                "When params is a dictionary, leave params_list set to None."
+                "params is not a list, but param_names was given. "
+                "When params is a dictionary, leave param_names set to None."
             )
             params_dict = {}
-            for index in len(self.params_list):
-                key = self.params_list[index]
+            for index in len(self.param_names):
+                key = self.param_names[index]
                 params_dict[key] = params[index]
             params = params_dict
         else:
             assert type(params) is dict, (
-                "params is not a dictionary, but no params_list was given. "
-                "params can be a dictionary, or a list if params_list is supplied."
+                "params is not a dictionary, but no param_names was given. "
+                "params can be a dictionary, or a list if param_names is supplied."
             )
         return params
 

--- a/src/pspec_likelihood/likelihood.py
+++ b/src/pspec_likelihood/likelihood.py
@@ -81,14 +81,14 @@ class PSpecLikelihood:
     k_bin_centres = attr.ib(converter=np.ndarray)
 
     little_h = attr.ib(
-        True, converter=bool, validator=attr.validators.is_instance(bool)
+        True, converter=bool, validator=attr.validators.instance_of(bool)
     )
     weight_by_cov = attr.ib(
-        True, converter=bool, validator=attr.validators.is_instance(bool)
+        True, converter=bool, validator=attr.validators.instance_of(bool)
     )
     history = attr.ib("", converter=str)
     run_check = attr.ib(True, converter=bool)
-    param_names = attr.ib(None, convert=attr.converters.optional(tuple))
+    param_names = attr.ib(None, converter=attr.converters.optional(tuple))
 
     @ps_files.validator
     def _check_existence(self, att, val):

--- a/src/pspec_likelihood/likelihood.py
+++ b/src/pspec_likelihood/likelihood.py
@@ -237,6 +237,37 @@ class PSpecLikelihood:
         # TODO: get redshift(s) z from spw / integrate
         raise NotImplementedError("Need to implement this.")
 
+    def params_to_dict(self, params):
+        r"""
+        Check if params is a list or dictionary. If list convert to dictionary using params_list.
+
+        Parameters
+        ----------
+        params : dictionary or list
+
+        Returns
+        ----------
+        params : dictionary
+            params convert to dictionary
+        """
+
+        if self.params_list is not None:
+            assert (
+                type(params) is list
+            ), ("params is not a list, but params_list was given. "
+                "When params is a dictionary, leave params_list set to None.")
+            params_dict = {}
+            for index in len(self.params_list):
+                key = self.params_list[index]
+                params_dict[key] = params[index]
+            params = params_dict
+        else:
+            assert (
+                type(params) is dict
+            ), ("params is not a dictionary, but no params_list was given. "
+                "params can be a dictionary, or a list if params_list is supplied.")
+        return params
+
     def log_unnormalized_likelihood(self, params):
         r"""
         log-likelihood for set of theoretical and bias parameters.
@@ -250,20 +281,6 @@ class PSpecLikelihood:
             This is the only function that accepts params as list or dict, other
             functions get called from here and take a dictionary.
         """
-        # Make sure that params is a dictionary or convert from list
-        if self.params_list is not None:
-            assert (
-                type(params) is list
-            ), "params is not a list, but params_list was given.\
-                When params is a dictionary, leave params_list set to None."
-            params_dict = {}
-            for index in len(self.params_list):
-                key = self.params_list[index]
-                params_dict[key] = params[index]
-            params = params_dict
-        else:
-            assert (
-                type(params) is dict
-            ), "params is not a dictionary, but no params_list was given.\
-                params can be a dictionary or a list if params_list is supplied."
+        params = params_to_dict(params)
+        raise NotImplementedError
         pass

--- a/src/pspec_likelihood/likelihood.py
+++ b/src/pspec_likelihood/likelihood.py
@@ -73,18 +73,23 @@ class PSpecLikelihood:
         be given as the list of corresponding parameter names (keys) so
         the list can internally be converted to a dictionary.
     """
+
     ps_files = attr.ib(converter=listify)
     theoretical_model = attr.ib(validator=attr.validators.is_callable())
     bias_model = attr.ib(validator=attr.validators.is_callable())
     k_bin_widths = attr.ib(converter=np.ndarray)
     k_bin_centres = attr.ib(converter=np.ndarray)
 
-    little_h = attr.ib(True, converter=bool, validator=attr.validators.is_instance(bool))
-    weight_by_cov = attr.ib(True, converter=bool, validator=attr.validators.is_instance(bool))
+    little_h = attr.ib(
+        True, converter=bool, validator=attr.validators.is_instance(bool)
+    )
+    weight_by_cov = attr.ib(
+        True, converter=bool, validator=attr.validators.is_instance(bool)
+    )
     history = attr.ib("", converter=str)
     run_check = attr.ib(True, converter=bool)
     param_names = attr.ib(None, convert=attr.converters.optional(tuple))
-                          
+
     @ps_files.validator
     def _check_existence(self, att, val):
         for fl in val:
@@ -105,7 +110,6 @@ class PSpecLikelihood:
         """The UVPSpec measurements."""
         uvp_in = UVPSpec(self.ps_files)
         return grouping.spherical_average(
-
             uvp_in,
             self.k_bin_centers,
             self.k_bin_widths,
@@ -224,7 +228,7 @@ class PSpecLikelihood:
 
         Parameters
         ----------
-        params : dictionary or list
+        params : dictionary, list or tuple
 
         Returns
         ----------

--- a/src/pspec_likelihood/likelihood.py
+++ b/src/pspec_likelihood/likelihood.py
@@ -237,30 +237,33 @@ class PSpecLikelihood:
         # TODO: get redshift(s) z from spw / integrate
         raise NotImplementedError("Need to implement this.")
 
+    def log_unnormalized_likelihood(self, params):
+        r"""
+        log-likelihood for set of theoretical and bias parameters.
 
-def log_unnormalized_likelihood(params):
-    r"""
-    log-likelihood for set of theoretical and bias parameters.
+        Probability of data given a model (this is distinct from a properly normalized posterior).
 
-    Probability of data given a model (this is distinct from a properly normalized posterior).
-
-    Parameters
-    ----------
-    params : dictionary or list
-        theoretical and systematics parameters to compute likelihood for.
-        This is the only function that accepts params as list or dict, other
-        functions get called from here and take a dictionary.
-    """
-    # Make sure that params is a dictionary or convert from list
-    if params_list != None:
-        assert type(params) is list, "params is not a list, but params_list was given.\
-            When params is a dictionary, leave params_list set to None."
-        params_dict = {}
-        for index in len(params_list):
-            key = params_list[index]
-            params_dict[key] = params[index]
-        params = params_dict
-    else:
-        assert type(params) is dict, "params is not a dictionary, but no params_list was given.\
-            params can be a dictionary or a list if params_list is supplied."
-    pass
+        Parameters
+        ----------
+        params : dictionary or list
+            theoretical and systematics parameters to compute likelihood for.
+            This is the only function that accepts params as list or dict, other
+            functions get called from here and take a dictionary.
+        """
+        # Make sure that params is a dictionary or convert from list
+        if self.params_list is not None:
+            assert (
+                type(params) is list
+            ), "params is not a list, but params_list was given.\
+                When params is a dictionary, leave params_list set to None."
+            params_dict = {}
+            for index in len(self.params_list):
+                key = self.params_list[index]
+                params_dict[key] = params[index]
+            params = params_dict
+        else:
+            assert (
+                type(params) is dict
+            ), "params is not a dictionary, but no params_list was given.\
+                params can be a dictionary or a list if params_list is supplied."
+        pass


### PR DESCRIPTION
This is useful for MCMC samplers and similar tools that pass
`params` as list instead of dictionary.
Note that `log_unnormalized_likelihood` is the only function that allows
for list of parameters. The list gets converted there and calls the
other functions. This avoids needing to convert this everywhere.

Resolves issue #7 