### PR TITLE
refactor: add attr as a dependency and refactor main class

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,7 @@ ignore =
     F403
     F401
     E231
+    D401
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9,D

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ package_dir =
 install_requires =
     hera_pspec @ git+git://github.com/hera-team/hera_pspec
     hera_sim @ git+git://github.com/hera-team/hera_sim
-    attrs
+    attr
 
 [options.packages.find]
 where = src

--- a/src/pspec_likelihood/utils.py
+++ b/src/pspec_likelihood/utils.py
@@ -1,0 +1,16 @@
+"""Miscellaneous utility functions."""
+from pathlib import Path
+
+
+def listify(x):
+    """If x is not a list, put it into one."""
+    if not isinstance(x, (list, tuple, set)):
+        return [x]
+    else:
+        return list(x)
+
+
+def make_list_of_paths(x):
+    """Convert a list of strings (or single string) into a list of Path objects."""
+    x = listify(x)
+    return [Path(xx) for xx in x]


### PR DESCRIPTION
Fixes #12 

This refactors the main class to use `attr`. It means specific validation can be done on each input argument. Also, it provides (for free) the `__eq__` and `__repr__` and `__str__` methods on the class. 