### PR TITLE
Fix auto-merge-deps workflow: use squash instead of merge commit

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -25,4 +25,4 @@ jobs:
 
       - name: Enable auto-merge
         if: ${{ github.event.pull_request.user.login == 'pre-commit-ci[bot]' || steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
- The "Enable auto-merge" step in `.github/workflows/auto-merge-deps.yml` runs `gh pr merge --auto --merge "$PR_URL"`, which fails with `GraphQL: Merge method merge commits are not allowed on this repository (enablePullRequestAutoMerge)` whenever the auto-merge condition actually triggers (Dependabot semver-patch/semver-minor, or pre-commit-ci).
- Root cause: branch protection on `main` has `required_linear_history` enabled, which rejects merge-commit auto-merge even though the repo-level setting nominally allows merge commits.
- Observed failing on #95 (release-drafter 7.2.1 → 7.7.0), [run 30690066006](https://github.com/HERA-Team/pspec_likelihood/actions/runs/30690066006/job/91343066820).
- Fix: switch to `--squash`, which is permitted and is already the repo's configured merge default (`squash_merge_commit_title: COMMIT_OR_PR_TITLE`).

This is a pre-existing infra bug unrelated to any specific dependency bump — the auto-merge automation currently doesn't work at all for qualifying Dependabot/pre-commit-ci PRs.

## Test plan
- [ ] Merge this PR
- [ ] Confirm the next qualifying Dependabot/pre-commit-ci PR auto-merges successfully via squash instead of failing with the merge-method GraphQL error

🤖 Generated with [Claude Code](https://claude.com/claude-code)